### PR TITLE
Removing return in Orchestra\Asset\Container::add() becaose it is causing exception when used in blade`s templates 

### DIFF
--- a/src/Orchestra/Asset/Container.php
+++ b/src/Orchestra/Asset/Container.php
@@ -80,13 +80,13 @@ class Container
      * @param  string  $source
      * @param  array   $dependencies
      * @param  array   $attributes
-     * @return self
+     * @return void
      */
     public function add($name, $source, $dependencies = array(), $attributes = array())
     {
         $type = (pathinfo($source, PATHINFO_EXTENSION) == 'css') ? 'style' : 'script';
 
-        return $this->$type($name, $source, $dependencies, $attributes);
+        $this->$type($name, $source, $dependencies, $attributes);
     }
 
     /**


### PR DESCRIPTION
``` php
{{ Orchestra\Asset::add('jquery', 'js/query.js') }}
```

Throws Exception in Blade templates when php trying to echo object
