### PR TITLE
Check, if start of the extension matches in Asset::add

### DIFF
--- a/src/Asset.php
+++ b/src/Asset.php
@@ -117,7 +117,7 @@ class Asset implements Htmlable
         $attributes = [],
         $replaces = []
     ) {
-        $type = (\pathinfo($source, PATHINFO_EXTENSION) == 'css') ? 'style' : 'script';
+        $type = (\strpos(\pathinfo($source, PATHINFO_EXTENSION), 'css') === 0) ? 'style' : 'script';
 
         return $this->$type($name, $source, $dependencies, $attributes, $replaces);
     }


### PR DESCRIPTION
Currently Asset::add method checks, if the whole extension matches 'css' and if not assumes that it belongs to scripts container.

This change makes sure that only the start of the extension matches 'css', so if we for example use 'something.css?id=12345', it will properly recognize it as style and not put it in scripts container.

This is useful, if you want to use your custom versioning (for example using Laravel Mix).