### PR TITLE
Add illuminate/filesystem as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,16 @@
     },
     "require": {
         "php": ">=7.2",
+        "illuminate/filesystem": "^6.0",
         "laravie/html": "^7.0",
         "orchestra/contracts": "^5.0",
         "orchestra/support-facades": "^5.0"
     },
     "require-dev": {
-        "illuminate/filesystem": "^7.0",
         "mockery/mockery": "^1.2.3",
         "orchestra/testbench": "^5.0"
     },
     "suggest": {
-        "illuminate/filesystem": "Allow using orchestra/asset component outside of Laravel app (^7.0).",
         "orchestra/html": "Allow using orchestra/asset with HTML component (^5.0)."
     },
     "extra": {


### PR DESCRIPTION
illuminate/filesystem is defacto requirement of this package, so it should be listed as such.

The package directly depends on it in the Dispatcher.
If a user of this package also uses Laravel, it will be installed anyway. If the user doesn't use Laravel, then it would need to be manually installed. In any case, the package has to be installed in order for orchestral/asset to work.
